### PR TITLE
Fix for AS7-SNAPSHOT

### DIFF
--- a/lib/torquespec/as7.rb
+++ b/lib/torquespec/as7.rb
@@ -24,12 +24,14 @@ module TorqueSpec
       begin
         domain_api( :operation => "add",
                     :address   => [ "deployment", addressify(path) ],
-                    :url       => urlify(path) )
-      rescue Exception
+                    :content   => [ { :url=>urlify(path)} ] )
+      rescue Exception=>e
         _undeploy(path)
         if once
           once = false
           retry
+        else
+          raise e 
         end
       end
       domain_api( :operation => "deploy",


### PR DESCRIPTION
To move to AS7-SNAPSHOT, the deployment API has changed slightly.

This breaks torquespec against Beta3, though, so I'm not sure how you'd like to handle it.  Hence fork+pull-request.
