### PR TITLE
Fix for bundler environment injection on Rails.

### DIFF
--- a/lib/torquespec/server.rb
+++ b/lib/torquespec/server.rb
@@ -70,6 +70,7 @@ module TorqueSpec
     protected
 
     def startup(opts)
+      ENV.delete 'RUBYOPTS' # nukes bundler as injected by rails apps in their test specs
       wait = opts[:wait].to_i
       cmd = start_command
       process = IO.popen( cmd )


### PR DESCRIPTION
This prevents Rails injection of the Bundler gem into the `RUBYOPTS` environment variable from blowing up the Torquebox server itself. The fix was suggested by bbrowning; I'm just pull request'ing it to be helpful.

Cheers!
