### PR TITLE
Add the option to make TorqueSpec a quieter

### DIFF
--- a/README.org
+++ b/README.org
@@ -206,6 +206,7 @@
    | ~jvm_args~   | Arguments to the JVM running JBoss                             | /see below/   |
    | ~drb_port~   | The in-container spec runner listens on this port for requests | 7772          |
    | ~lazy~       | Whether to use a running JBoss and leave it running when done  | false         |
+   | ~verbose~    | Whether or not to emit extra messages during the run           | true          |
 
    By default, TorqueSpec is initialized thusly:
 
@@ -213,6 +214,7 @@
    :   config.drb_port = 7772
    :   config.knob_root = ".torquespec"
    :   config.jvm_args = "-Xms64m -Xmx1024m -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -Dgem.path=default"
+   :   config.verbose = false
    : end
 
    Include a similar block in your =spec_helper.rb= to customize any of these.

--- a/lib/torquespec/server.rb
+++ b/lib/torquespec/server.rb
@@ -13,11 +13,11 @@ module TorqueSpec
     def start(opts={})
       if ready?
         if TorqueSpec.lazy
-          puts "Using running JBoss (try lazy=false if you get errors)"
+          RSpec.configuration.reporter.message "Using running JBoss (try lazy=false if you get errors)" if TorqueSpec.verbose?
           return
         else
           stop
-          puts "Waiting for running JBoss to shutdown"
+          RSpec.configuration.reporter.message "Waiting for running JBoss to shutdown" if TorqueSpec.verbose?
           sleep(5)
           sleep(1) while ready?
           self.stopped = false
@@ -30,19 +30,18 @@ module TorqueSpec
       return if stopped
       self.stopped = true
       if TorqueSpec.lazy
-        puts "JBoss won't be stopped (lazy=true)"
+        RSpec.configuration.reporter.message "JBoss won't be stopped (lazy=true)" if TorqueSpec.verbose?
       else
         shutdown
-        puts "Shutdown message sent to JBoss"
+        RSpec.configuration.reporter.message "Shutdown message sent to JBoss" if TorqueSpec.verbose?
       end
     end
 
     def deploy(url)
       t0 = Time.now
-      print "deploy #{url} "
-      $stdout.flush
+      RSpec.configuration.reporter.message "deploy #{url} "
       _deploy(url)
-      puts "in #{(Time.now - t0).to_i}s"
+      RSpec.configuration.reporter.message "in #{(Time.now - t0).to_i}s"
     end
 
     def undeploy(url)
@@ -55,11 +54,11 @@ module TorqueSpec
     end
 
     def wait_for_ready(timeout)
-      puts "Waiting up to #{timeout}s for JBoss to boot"
+      RSpec.configuration.reporter.message "Waiting up to #{timeout}s for JBoss to boot" if TorqueSpec.verbose?
       t0 = Time.now
       while (Time.now - t0 < timeout && !stopped) do
         if ready?
-          puts "JBoss started in #{(Time.now - t0).to_i}s"
+          RSpec.configuration.reporter.message "JBoss started in #{(Time.now - t0).to_i}s" if TorqueSpec.verbose?
           return true
         end
         sleep(1)
@@ -77,7 +76,7 @@ module TorqueSpec
       self.server_pid = process.pid
       Thread.new(process) { |console| while(console.gets); end }
       %w{ INT TERM KILL }.each { |signal| trap(signal) { stop } }
-      puts "#{cmd}\npid=#{process.pid}"
+      RSpec.configuration.reporter.message "#{cmd}\npid=#{process.pid}" if TorqueSpec.verbose?
       wait > 0 ? wait_for_ready(wait) : process.pid
     end
 

--- a/lib/torquespec/torquespec.rb
+++ b/lib/torquespec/torquespec.rb
@@ -20,7 +20,7 @@ module TorqueSpec
   end
 
   class << self
-    attr_accessor :knob_root, :jboss_home, :jvm_args, :max_heap, :lazy, :drb_port, :spec_dir, :domain_mode
+    attr_accessor :knob_root, :jboss_home, :jvm_args, :max_heap, :lazy, :drb_port, :spec_dir, :domain_mode, :verbose
     def configure
       yield self
     end
@@ -44,6 +44,9 @@ module TorqueSpec
       TorqueBox::Server.jboss_home
     rescue Exception
       $stderr.puts "WARN: Unable to determine JBoss install location; set either TorqueSpec.jboss_home or ENV['JBOSS_HOME']"
+    end
+    def verbose?
+      @verbose
     end
   end
 
@@ -93,5 +96,7 @@ TorqueSpec.configure do |config|
   config.knob_root = ".torquespec"
   config.domain_mode = %w(yes true 1).include?(java.lang.System.getProperty('domain.mode') || ENV['DOMAIN_MODE'])
   config.jvm_args = "-Xms64m -Xmx1024m -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -Djruby.home=#{config.jruby_home}"
+  config.verbose = false
 end
+
 


### PR DESCRIPTION
- Changes as many print statements as I could find to use an RSpec message call instead. This should cause any output to be emitted if the test fails, and otherwise not disrupt the lovely line of green dots we all know your specs produce.
- Adds a verbose configuration option (on by default to be closer to original functionality).

This might need some tweaking for acceptance criteria, but keeping the output as terse as possible (until something blows up - then I want data) is important to me, so I figure'd I'd make a PR for this one.

As an example of the lovely quietness this can bring, I present this screenshot: http://nserror.me/upsht/upshot_quieterTorquespec.png
