### PR TITLE
Fix TorqueSpec working with RSpec 2.13

### DIFF
--- a/lib/torquespec/daemon.rb
+++ b/lib/torquespec/daemon.rb
@@ -158,13 +158,16 @@ end
 # all exceptions into Exceptions.
 module TorqueSpec
   def self.dump(exception)
-    Marshal.dump( [exception.message, exception.backtrace] )
+    pending_fixed = exception.pending_fixed? rescue :do_not_add
+    Marshal.dump( [exception.message, exception.backtrace, pending_fixed] )
   end
   def self.load_exception(str)
-    message, trace = Marshal.load(str)
+    message, trace, pending_fixed = Marshal.load(str)
     exception = ::Exception.new(message)
     meta = class << exception; self; end
     meta.send(:define_method, :backtrace) { trace }
+    pending_fixed == :do_not_add or
+      meta.send(:define_method, :pending_fixed?) { pending_fixed }
     exception
   end
 end

--- a/lib/torquespec/daemon.rb
+++ b/lib/torquespec/daemon.rb
@@ -124,6 +124,13 @@ module RSpec
         @metadata = data
       end
     end
+
+    class Time
+      def marshal_dump
+      end
+      def marshal_load data
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This should fix #6, implementing the additional features ^W hacks that get newer RSpec versions working correctly with TorqueSpec.  Using these two changes I can successfully run my specs in-container using rspec-core 2.13.0.
